### PR TITLE
fix(ADS-3397, ADS-3398): parquet-avro, jersey-bom and ftpserver versions bump

### DIFF
--- a/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-parquet-bundle/nifi-parquet-processors/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-avro</artifactId>
-            <version>1.13.1</version>
+            <version>1.15.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.xerial.snappy</groupId>

--- a/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-standard-bundle/nifi-standard-processors/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <ozone.version>1.2.1</ozone.version>
         <gcs.version>2.1.9</gcs.version>
         <aspectj.version>1.9.6</aspectj.version>
-        <jersey.bom.version>2.45</jersey.bom.version>
+        <jersey.bom.version>2.48</jersey.bom.version>
         <log4j2.version>2.24.1</log4j2.version>
         <mockito.version>4.11.0</mockito.version>
         <logback.version>1.3.14</logback.version>


### PR DESCRIPTION
Bump version of dependencies to address CVEs