### PR TITLE
fix: missing libs in nifi and registry assembly

### DIFF
--- a/nifi-assembly/pom.xml
+++ b/nifi-assembly/pom.xml
@@ -1589,6 +1589,20 @@ language governing permissions and limitations under the License. -->
                     <groupId>org.apache.nifi</groupId>
                     <artifactId>nifi-ranger-resources</artifactId>
                     <version>1.28.1</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>net.minidev</groupId>
+                            <artifactId>json-smart</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>net.minidev</groupId>
+                            <artifactId>accessors-smart</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>

--- a/nifi-registry/nifi-registry-assembly/pom.xml
+++ b/nifi-registry/nifi-registry-assembly/pom.xml
@@ -406,6 +406,24 @@
                     <classifier>bin</classifier>
                     <scope>runtime</scope>
                     <type>${nifi.registry.extension.archive.type}</type>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-core</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>net.minidev</groupId>
+                            <artifactId>json-smart</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>net.minidev</groupId>
+                            <artifactId>accessors-smart</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.apache.httpcomponents</groupId>
+                            <artifactId>httpcore</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
             <build>


### PR DESCRIPTION
excluded some ranger libs from the assembly because they were located shallower that the nifi and registry assembly in the dependency resolver tree. Because of that they were only included in the ranger plugin assembly and not included in the main nifi and registry assembly archive